### PR TITLE
ページ遷移した時にスクロール位置をTOPに戻す

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -91,7 +91,15 @@ const router = createRouter({
         }
       ]
     },
-  ]
+  ],
+  // ページ遷移でスクロール位置を TOP に戻す
+  scrollBehavior(_to, _from, savedPosition) {
+    if (savedPosition) {
+      return savedPosition
+    } else {
+      return { top: 0 }
+    }
+  },
 })
 
 export default router


### PR DESCRIPTION
## 📝 関連する課題 / Related Issues

- #30

## ⛏ 変更内容 / Details of Changes

- Vue Router のページ遷移時のスクロールリセット処理を追加しました [033cfdf74be22806acb9fcf1590a6a1957b61917]

## 📸 スクリーンショット / Screenshots

<details>
<summary>スクリーンショット一覧</summary>

- 動作確認

https://user-images.githubusercontent.com/54354176/227794557-0e0a41c3-e00f-44cb-b4b7-4b79f664eca5.mp4

</details>

## 💬 備考 / Remarks

- 念の為、`npm run build` & `npm run preview` の実行でも動作に問題ないことを確認しました。

こちら、お手隙の際にレビューのほどよろしくお願いいたします。