### PR TITLE
ブログページにogpを追加

### DIFF
--- a/src/views/News/_id.vue
+++ b/src/views/News/_id.vue
@@ -1,20 +1,29 @@
 <script setup>
-import { ref } from 'vue'
-import Api from '../../api/api.js'
-import '../../assets/css/github_md.css'
+import { ref } from "vue";
+import Api from "../../api/api.js";
+import "../../assets/css/github_md.css";
 
 const props = defineProps({
-  id: Number
-})
+  id: Number,
+});
 const news = ref([]);
 Api.fetchNews(props.id).then((data) => {
-  console.log(data)
   news.value = data;
+  const ogDescription = document.querySelector(
+    'meta[property="og:description"]'
+  );
+
+  ogDescription.setAttribute("content", news.value.title);
+  const ogImage = document.querySelector('meta[property="og:image"]');
+  const ogpUrl = news.value.ogp.url;
+  if (news.value.ogp.url) {
+    ogImage.setAttribute("content", ogpUrl);
+  }
 });
 </script>
 <template>
- <section class="section markdown-body">
-  <h1 class="text-center text-xl font-bold py-16">{{ news.title }}</h1>
-  <div v-html="news.content"></div>
- </section>
+  <section class="section markdown-body">
+    <h1 class="text-center text-xl font-bold py-16">{{ news.title }}</h1>
+    <div v-html="news.content"></div>
+  </section>
 </template>


### PR DESCRIPTION
## 📝 関連する課題 / Related Issues

- [#66](https://github.com/Drop-in-Hachinohe/Dropin/issues/66) 記事をシェアしたときに記事の画像や文章が表示されるようしたい

## ⛏ 変更内容 / Details of Changes

ブログページを読み込む際にheaderのmetaタグを書き換える処理を追加


## 📸 スクリーンショット / Screenshots

<details>
<summary>スクリーンショット一覧</summary>

- 

</details>

## 💬 備考 / Remarks

- 
